### PR TITLE
Making in_array check strict to allow serializing numeric indexed arrays

### DIFF
--- a/src/SecretMessageSerializer.php
+++ b/src/SecretMessageSerializer.php
@@ -59,7 +59,7 @@ class SecretMessageSerializer implements MessageSerializer
     private function obscureArray(array $data)
     {
         foreach ($data as $key => $value) {
-            if (in_array($key, $this->secretFields)) {
+            if (in_array($key, $this->secretFields, true)) {
                 $data[$key] = $this->placeHolder;
             }
 

--- a/tests/SecretMessageSerializerTest.php
+++ b/tests/SecretMessageSerializerTest.php
@@ -49,10 +49,15 @@ class SecretMessageSerializerTest extends \PHPUnit_Framework_TestCase
     public function it_will_return_obscure_values_for_items_in_secret_array()
     {
         $command = 'string_command';
-        $expected = ['password' => '[SECRET]', 'abc' => '123'];
+        $expected = ['password' => '[SECRET]', 'abc' => '123', 'numeric_array' => ['foo', 'bar']];
+
         $this->messageSerializer->serializeCommand($command)->willReturn([
             'password' => '123',
             'abc' => '123',
+            'numeric_array' => [
+                'foo',
+                'bar'
+            ]
         ]);
 
         $actual = $this->SUT->serializeCommand($command);


### PR DESCRIPTION
When using this plugin I realized I had a lot of SECRETS in my log, e.g.:
`"connection": ["[SECRET]"], "user-agent": ["[SECRET]"], content-type": ["[SECRET]"], "cache-control": ["[SECRET]"]`

The reason is that all of these entries are an numeric array with one entry. The '`in_array check` coerces the strings in secretFields to 0, therefore it always obscures the values (see https://3v4l.org/voD9Q).

This PR fixes this by adding the 3 parameter to in_array.